### PR TITLE
fix: add mongodb atlas url to vercel configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -13,7 +13,8 @@
     }
   },
   "env": {
-    "NODE_ENV": "production"
+    "NODE_ENV": "production",
+    "MONGO_URL": "mongodb+srv://iamhuraira429:o0RO84l6TjbgQB5S@hurii.8wtzhom.mongodb.net/pharmaKhata?retryWrites=true&w=majority&appName=hurii"
   },
   "headers": [
     {


### PR DESCRIPTION
- add MONGO_URL environment variable to vercel.json
- ensure production uses mongodb atlas instead of localhost
- fix connection issues on vercel deployment